### PR TITLE
Yields a state object

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,24 @@ In a template use the `async-button` helper
 {{async-button action=(action "save" model) default="Save" pending="Saving..."}}
 ```
 
+### With a block ###
+
 The component can also take a block:
 
 ```handlebars
-{{#async-button action=(action "save")}}
-  Template content.
+{{#async-button action=(action "save") as |component state|}}
+  {{#if state.isDefault}}
+    Click here to save
+  {{/if}}
+  {{#if state.isPending}}
+    Please wait...
+  {{/if}}
+  {{#if state.isFulfilled}}
+    Everything went well, congrats!
+  {{/if}}
+  {{#if state.isRejected}}
+    Ooops, something went wrong.
+  {{/if}}
 {{/async-button}}
 ```
 

--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -19,6 +19,7 @@ const ButtonComponent = Component.extend(positionalParamsMixin, {
   layout,
   tagName: 'button',
   textState: 'default',
+  asyncState: computed.alias('default'),
   reset: false,
   classNames: ['async-button'],
   classNameBindings: ['textState'],
@@ -122,6 +123,18 @@ The callback for closure actions will be removed in future versions.`,
     if (tagName === 'a' && href === undefined) {
       return '';
     }
+  }),
+
+  _stateObject: computed('textState', function() {
+    let textState = get(this, 'textState');
+    let isFulfilled = textState === 'fulfilled' || textState === 'resolved';
+    return {
+      isPending: textState === 'pending',
+      isFulfilled,
+      isResolved: isFulfilled,
+      isRejected: textState === 'rejected',
+      isDefault: textState === 'default'
+    };
   })
 });
 

--- a/addon/templates/components/async-button.hbs
+++ b/addon/templates/components/async-button.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{yield this}}
+  {{yield this _stateObject}}
 {{else}}
   {{text}}
 {{/if}}

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -217,3 +217,26 @@ test('Block form yields correctly', function() {
     contains(find(buttonSelector), 'Saved!');
   });
 });
+
+test('Yield state', function() {
+  visit('/');
+
+  andThen(function() {
+    contains(find('#state-yield button.async-button'), 'default');
+  });
+
+  andThen(function() {
+    run(()=> click('#state-yield button.async-button'));
+    contains(find('#state-yield button.async-button'), 'pending');
+  });
+
+  andThen(function() {
+    run(()=> set(AppController, 'promise', reject()));
+    contains(find('#state-yield button.async-button'), 'rejected');
+  });
+
+  andThen(function() {
+    run(()=> set(AppController, 'promise', resolve()));
+    contains(find('#state-yield button.async-button'), 'fulfilled');
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -27,4 +27,13 @@
   {{button.text}}
 {{/async-button}}
 </div>
+
+<div id="state-yield">
+  {{#async-button promise=promise as |button state|}}
+    {{#if state.isFulfilled}} fulfilled {{/if}}
+    {{#if state.isPending}} pending {{/if}}
+    {{#if state.isRejected}} rejected {{/if}}
+    {{#if state.isDefault}} default {{/if}}
+  {{/async-button}}
+</div>
 {{outlet}}


### PR DESCRIPTION
This PR does 2 things:
* rename `textState` to `currentState` (I personally found textState confusing)
* yield a state object to the block, in addition to the component itself (for backward compatibility).

The later allows for better control of the contents in the template, see:

```handlebars
<!-- before -->
{{async-button action="save" as |block|}}
  {{#if (eq block.textState "pending")}}
    Please wait...
  {{/if}}
{{/async-button}}

<!-- after -->
{{async-button action="save" as |block state|}}
  {{#if state.isPending}}
    Please wait...
  {{/if}}
{{/async-button}}
```

The advantage of the state object is to avoid doing string comparison in templates, which is error prone and forces the app developer to either build a helper or install `ember-truth-helpers`.

I hope you'll like it!